### PR TITLE
fixed qml to load file

### DIFF
--- a/qt/res/Window.qml
+++ b/qt/res/Window.qml
@@ -157,7 +157,7 @@ ApplicationWindow {
 		onAccepted: {
 			// cut off the "file://" part
 			var path = fileOpenDialog.fileUrls.toString().substring(7)
-			var sess = Panopticon.openPanopticon(path)
+			var sess = Panopticon.openSession(path)
 
 			if(sess == null) {
 				console.log("The file '" + path + "' is not a valid Panopticon session.")


### PR DESCRIPTION
I  just wanted to try out your UI (I know it's work in progress) and recognized that a non-existing method (`openPanopticon`) is called. I changed it to `openSession` and could open the file `sosse`. I'm not sure if this is how it's supposed to work but it does. ( I guess you are still heavily working on your port to Rust, so feel free to ignore this PR, otherwise I am happy for my first small contribution to your interesting project :-)
Cheers,
Ismail
